### PR TITLE
Legger til https på appres

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-APPRES_CMS_URL=http://appres.nav.no
+APPRES_CMS_URL=https://appres.nav.no
 PORT=8080
 REACT_APP_CONTEXT_ROOT=/oppfolgingsplan
 REACT_APP_SYFOREST_ROOT=/syforest


### PR DESCRIPTION
Nylige DNS-endringer gjør visst at applikasjonen sliter med å starte opp i Heroku når dekoratøren hentes fra HTTP. Jeg har allerede deployet en versjon med denne endringer til Heroku for å teste at dette fungerer!