### PR TITLE
Show GodkjenPlanLightboks under GodkjennPlanOversiktInformasjon

### DIFF
--- a/js/components/oppfolgingsdialoger/OppfolgingsdialogerInfoPersonvern.js
+++ b/js/components/oppfolgingsdialoger/OppfolgingsdialogerInfoPersonvern.js
@@ -5,6 +5,7 @@ const texts = {
         Oppfølgingsplanen skal gjøre det lettere for deg å bli i jobben.
         Du og arbeidsgiveren lager planen sammen og skriver inn opplysninger fra hver deres kant.
         Formålet er finne ut hvilke oppgaver du kan gjøre hvis det legges til rette. Dere kan endre planen når som helst etter hvert som dere ser hvordan det går.
+        Alle godkjente planer mellom deg og arbeidsgiveren vil også bli tilgjengelige for arbeidsplassen i Altinn.
     `,
     readMore: {
         title: 'Les mer om:',

--- a/js/components/oppfolgingsplan/godkjenn/godkjenn/Godkjenn.js
+++ b/js/components/oppfolgingsplan/godkjenn/godkjenn/Godkjenn.js
@@ -50,31 +50,27 @@ class Godkjenn extends Component {
             settAktivtSteg,
             rootUrl,
         } = this.props;
-        return (<div>
-            {
-                (() => {
-                    if (this.state.visGodkjenPlanSkjema) {
-                        return (<GodkjennPlanLightboks
-                            avbryt={this.lukkGodkjenPlanSkjema}
-                            rootUrl={rootUrl}
-                            oppfolgingsdialog={oppfolgingsdialog}
-                            godkjennPlan={this.sendGodkjennPlan}
-                        />);
-                    }
-                    return (<div ref={this.formRef} className="godkjennPlanOversikt">
-                        <GodkjennPlanOversiktInformasjon
-                            oppfolgingsdialog={oppfolgingsdialog}
-                            rootUrl={rootUrl}
-                        />
+        return (<div ref={this.formRef} className="godkjennPlanOversikt">
+            <GodkjennPlanOversiktInformasjon
+                oppfolgingsdialog={oppfolgingsdialog}
+                rootUrl={rootUrl}
+            />
+            {!this.state.visGodkjenPlanSkjema &&
+            <ReviderEllerGodkjennPlan
+                oppfolgingsdialog={oppfolgingsdialog}
+                rootUrl={rootUrl}
+                settAktivtSteg={settAktivtSteg}
+                visSendTilGodkjenning={this.visGodkjenPlanSkjema}
+            />
+            }
 
-                        <ReviderEllerGodkjennPlan
-                            oppfolgingsdialog={oppfolgingsdialog}
-                            rootUrl={rootUrl}
-                            settAktivtSteg={settAktivtSteg}
-                            visSendTilGodkjenning={this.visGodkjenPlanSkjema}
-                        />
-                    </div>);
-                })()
+            {this.state.visGodkjenPlanSkjema &&
+            <GodkjennPlanLightboks
+                avbryt={this.lukkGodkjenPlanSkjema}
+                rootUrl={rootUrl}
+                oppfolgingsdialog={oppfolgingsdialog}
+                godkjennPlan={this.sendGodkjennPlan}
+            />
             }
         </div>);
     }

--- a/js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanLightboks.js
+++ b/js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanLightboks.js
@@ -13,13 +13,10 @@ import { erIkkeOppfolgingsdialogUtfylt } from '../../../../utils/oppfolgingsdial
 import CheckboxSelvstendig from '../../../skjema/CheckboxSelvstendig';
 import GodkjennPlanSkjemaDatovelger from './GodkjennPlanSkjemaDatovelger';
 import { oppfolgingsplanPt } from '../../../../propTypes/opproptypes';
+import GodkjennPlanVenterInfo from './GodkjennPlanVenterInfo';
 
 const texts = {
-    title: 'Du sender nå en oppfølgingsplan til arbeidsgiveren din for godkjenning',
-    info: `
-        Arbeidsgiveren din kan deretter gjøre endringer i oppfølgingsplanen.
-        Da får du den til ny godkjenning. Alle godkjente planer mellom deg og arbeidsgiveren vil også bli tilgjengelige for arbeidsplassen i Altinn.
-    `,
+    title: 'Send til arbeidsgiveren din for godkjenning',
     titleDatovelger: 'Når skal planen vare fra og til?',
     checkboxLabel: 'Jeg er enig i denne oppfølgingsplanen',
     buttonSend: 'Send til godkjenning',
@@ -94,7 +91,7 @@ export class GodkjennPlanLightboksComponent extends Component {
             <form onSubmit={handleSubmit(this.godkjennPlan)} className="godkjennPlanSkjema">
                 <h2>{texts.title}</h2>
 
-                <p>{texts.info}</p>
+                <GodkjennPlanVenterInfo />
 
                 <hr />
 

--- a/js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanVenterInfo.js
+++ b/js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanVenterInfo.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const texts = {
+    infolist: {
+        ingress: 'Arbeidsgiveren din kan enten godkjenne eller gjøre endringer i oppfølgingsplanen:',
+        noChangesApproval: 'Godkjenner arbeidsgiveren vil du motta et varsel om at har dere opprettet en gjeldende plan.',
+        changesWithAproval: 'Gjør arbeisgiveren endringer og sender den tilbake til deg for godkjenning, vil du motta et varsel om å ta stilling dette.',
+        changesNoApproval: `
+            Mottar du ikke varsel knyttet til planen har ikke arbeidsgiveren din tatt stilling til den. 
+            For å komme videre kan du ta kontakt med din arbeidsgiver eller logge inn på Ditt NAV og se om det er gjort endringer i oppfølgingsplanen. 
+        `,
+    },
+};
+
+
+const GodkjennPlanVenterInfo = () => {
+    return (
+        <React.Fragment>
+            <p>{texts.infolist.ingress}</p>
+            <ul>
+                <li>{texts.infolist.noChangesApproval}</li>
+                <li>{texts.infolist.changesWithAproval}</li>
+                <li>{texts.infolist.changesNoApproval}</li>
+            </ul>
+        </React.Fragment>);
+};
+
+export default GodkjennPlanVenterInfo;

--- a/js/components/oppfolgingsplan/godkjenn/godkjenn/ReviderEllerGodkjennPlan.js
+++ b/js/components/oppfolgingsplan/godkjenn/godkjenn/ReviderEllerGodkjennPlan.js
@@ -8,7 +8,7 @@ import { erIkkeOppfolgingsdialogUtfylt } from '../../../../utils/oppfolgingsdial
 import IkkeUtfyltPlanFeilmelding from './IkkeUtfyltPlanFeilmelding';
 
 const texts = {
-    bjorn: 'Er du ferdig med denne planen og ønsker å sende den til godkjenning?',
+    bjorn: 'Er du ferdig med denne planen og ønsker å sende den til arbeidsgiveren din for godkjenning?',
     buttonGodkjenn: 'Jeg er ferdig',
 };
 

--- a/js/components/oppfolgingsplan/godkjenn/godkjenninger/GodkjennPlanSendt.js
+++ b/js/components/oppfolgingsplan/godkjenn/godkjenninger/GodkjennPlanSendt.js
@@ -7,11 +7,11 @@ import GodkjennPlanOversiktInformasjon from '../godkjenn/GodkjennPlanOversiktInf
 import OppfolgingsplanInnholdboks from '../../../app/OppfolgingsplanInnholdboks';
 import GodkjennPlanTidspunkt from '../GodkjennPlanTidspunkt';
 import TidligereAvbruttePlaner from '../TidligereAvbruttePlaner';
+import GodkjennPlanVenterInfo from '../godkjenn/GodkjennPlanVenterInfo';
 
 const texts = {
     godkjennPlanSendtInfoTekst: {
         title: 'Hva skjer nå?',
-        paragraph: 'Når arbeidsgiveren din har godkjent den nye planen, vil du få muligheten til å laste den ned.',
     },
     godkjennPlanSendtUtvidbar: {
         title: 'Se planen',
@@ -35,9 +35,9 @@ const GodkjenPlanSentBlokk = (narmestelederName) => {
 
 export const GodkjennPlanSendtInfoTekst = () => {
     return (
-        <div className="godkjennPlanSendt_infoTekst">
+        <div className="blokk godkjennPlanSendt_infoTekst">
             <h3 className="typo-element">{texts.godkjennPlanSendtInfoTekst.title}</h3>
-            <p>{texts.godkjennPlanSendtInfoTekst.paragraph}</p>
+            <GodkjennPlanVenterInfo />
         </div>
     );
 };
@@ -77,6 +77,13 @@ const GodkjennPlanSendt = ({ oppfolgingsdialog, nullstillGodkjenning, rootUrl, r
                     oppfolgingsdialog={oppfolgingsdialog}
                     rootUrl={rootUrl}
                 />
+                <button
+                    className="lenke lenke--avbryt"
+                    onClick={() => {
+                        nullstillGodkjenning(oppfolgingsdialog.id, oppfolgingsdialog.arbeidstaker.fnr);
+                    }}>
+                    {texts.godkjennPlanSendt.buttonUndo}
+                </button>
                 <TidligereAvbruttePlaner
                     oppfolgingsdialog={oppfolgingsdialog}
                     rootUrlPlaner={rootUrlPlaner}
@@ -84,13 +91,6 @@ const GodkjennPlanSendt = ({ oppfolgingsdialog, nullstillGodkjenning, rootUrl, r
                 <GodkjennPlanSendtInfoTekst
                     oppfolgingsdialog={oppfolgingsdialog}
                 />
-                <button
-                    className="lenke"
-                    onClick={() => {
-                        nullstillGodkjenning(oppfolgingsdialog.id, oppfolgingsdialog.arbeidstaker.fnr);
-                    }}>
-                    {texts.godkjennPlanSendt.buttonUndo}
-                </button>
             </div>
         </OppfolgingsplanInnholdboks>
     );

--- a/styles/_godkjennPlanSendt.less
+++ b/styles/_godkjennPlanSendt.less
@@ -2,4 +2,7 @@
     .tidligereAvbruttePlaner {
         margin-top: 2em;
     }
+    .lenke--avbryt {
+        margin-top: 1em;
+    }
 }

--- a/test/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanLightboksTest.js
+++ b/test/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanLightboksTest.js
@@ -8,6 +8,7 @@ import { Hovedknapp } from 'nav-frontend-knapper';
 import { GodkjennPlanLightboksComponent } from '../../../../../js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanLightboks';
 import GodkjennPlanSkjemaDatovelger from '../../../../../js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanSkjemaDatovelger';
 import getOppfolgingsdialog from '../../../../mock/mockOppfolgingsdialog';
+import GodkjennPlanVenterInfo from '../../../../../js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanVenterInfo';
 
 chai.use(chaiEnzyme());
 const expect = chai.expect;
@@ -38,7 +39,9 @@ describe('GodkjennPlanLightboks', () => {
     it('Skal vise overskrifter og tekster', () => {
         expect(komponent.find('h2')).to.have.length(1);
         expect(komponent.find('h3')).to.have.length(1);
-        expect(komponent.find('p')).to.have.length(1);
+    });
+    it('Skal vise GodkjennPlanVenterInfo', () => {
+        expect(komponent.find(GodkjennPlanVenterInfo)).to.have.length(1);
     });
 
     it('Skal vise GodkjennPlanSkjemaDatovelger', () => {

--- a/test/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennTest.js
+++ b/test/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennTest.js
@@ -5,6 +5,7 @@ import chaiEnzyme from 'chai-enzyme';
 import Godkjenn from '../../../../../js/components/oppfolgingsplan/godkjenn/godkjenn/Godkjenn';
 import GodkjennPlanOversiktInformasjon from '../../../../../js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanOversiktInformasjon';
 import GodkjennPlanLightboks from '../../../../../js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanLightboks';
+import ReviderEllerGodkjennPlan from '../../../../../js/components/oppfolgingsplan/godkjenn/godkjenn/ReviderEllerGodkjennPlan';
 
 chai.use(chaiEnzyme());
 const expect = chai.expect;
@@ -45,11 +46,35 @@ describe('Godkjenn', () => {
         expect(komponentDefault.find(GodkjennPlanOversiktInformasjon)).to.have.length(1);
     });
 
-    it('Skal vise et GodkjennPlanLightboks, dersom visGodkjenPlanSkjema er true', () => {
+    it('Skal vise ReviderEllerGodkjennPlan, om visGodkjenPlanSkjema er false', () => {
+        const komponent = shallow(<Godkjenn />, { disableLifecycleMethods: true });
+        komponent.setState({
+            visGodkjenPlanSkjema: false,
+        });
+        expect(komponent.find(ReviderEllerGodkjennPlan)).to.have.length(1);
+    });
+
+    it('Skal ikke vise ReviderEllerGodkjennPlan, om visGodkjenPlanSkjema er true', () => {
+        const komponent = shallow(<Godkjenn />, { disableLifecycleMethods: true });
+        komponent.setState({
+            visGodkjenPlanSkjema: true,
+        });
+        expect(komponent.find(ReviderEllerGodkjennPlan)).to.have.length(0);
+    });
+
+    it('Skal vise GodkjennPlanLightboks, om visGodkjenPlanSkjema er true', () => {
         const komponent = shallow(<Godkjenn />, { disableLifecycleMethods: true });
         komponent.setState({
             visGodkjenPlanSkjema: true,
         });
         expect(komponent.find(GodkjennPlanLightboks)).to.have.length(1);
+    });
+
+    it('Skal ikke vise GodkjennPlanLightboks, om visGodkjenPlanSkjema er false', () => {
+        const komponent = shallow(<Godkjenn />, { disableLifecycleMethods: true });
+        komponent.setState({
+            visGodkjenPlanSkjema: false,
+        });
+        expect(komponent.find(GodkjennPlanLightboks)).to.have.length(0);
     });
 });

--- a/test/components/oppfolgingsplan/godkjenninger/GodkjennPlanSendtTest.js
+++ b/test/components/oppfolgingsplan/godkjenninger/GodkjennPlanSendtTest.js
@@ -10,6 +10,7 @@ import GodkjennPlanSendt, {
 import OppfolgingsplanInnholdboks from '../../../../js/components/app/OppfolgingsplanInnholdboks';
 import GodkjennPlanOversiktInformasjon from '../../../../js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanOversiktInformasjon';
 import getOppfolgingsdialog from '../../../mock/mockOppfolgingsdialog';
+import GodkjennPlanVenterInfo from '../../../../js/components/oppfolgingsplan/godkjenn/godkjenn/GodkjennPlanVenterInfo';
 
 chai.use(chaiEnzyme());
 const expect = chai.expect;
@@ -65,7 +66,10 @@ describe('GodkjennPlanSendt', () => {
         it('Skal vise en GodkjennPlanSendtInfoTekst med overskrift og tekst', () => {
             expect(komponent.find('div.godkjennPlanSendt_infoTekst')).to.have.length(1);
             expect(komponent.find('h3')).to.have.length(1);
-            expect(komponent.find('p')).to.have.length(1);
+        });
+
+        it('Skal vise GodkjennPlanVenterInfo', () => {
+            expect(komponent.find(GodkjennPlanVenterInfo)).to.have.length(1);
         });
     });
 });


### PR DESCRIPTION
- Flytter siste visning for sending av plan til godkjenning slik at den vises under visning for oppfolgingsplan i stedet for å gi arbeidstaker en ny visning.
- Lager utfyllende tekst for  som informerer arbeidstaker om hva som skjer etter at planen er sendt til arbeidsgiver for godkjenning.
