### PR TITLE
Check if leader is active, if not, display warning

### DIFF
--- a/js/utils/stateUtils.js
+++ b/js/utils/stateUtils.js
@@ -26,7 +26,9 @@ const finnNaermesteLeder = (fnr, virksomhetsnummer, state) => {
   return (
     state.naermesteleder.data
       .filter((naermesteleder) => {
-        return naermesteleder.fnr === fnr && naermesteleder.virksomhetsnummer === virksomhetsnummer;
+        return (
+          naermesteleder.fnr === fnr && naermesteleder.virksomhetsnummer === virksomhetsnummer && naermesteleder.erAktiv
+        );
       })
       .map((naermesteleder) => {
         return naermesteleder.naermesteLeder;

--- a/js/utils/stateUtils.js
+++ b/js/utils/stateUtils.js
@@ -27,7 +27,9 @@ const finnNaermesteLeder = (fnr, virksomhetsnummer, state) => {
     state.naermesteleder.data
       .filter((naermesteleder) => {
         return (
-          naermesteleder.fnr === fnr && naermesteleder.virksomhetsnummer === virksomhetsnummer && naermesteleder.erAktiv
+          naermesteleder.fnr === fnr &&
+          naermesteleder.virksomhetsnummer === virksomhetsnummer &&
+          naermesteleder.naermesteLeder.erAktiv
         );
       })
       .map((naermesteleder) => {

--- a/js/utils/sykmeldingUtils.js
+++ b/js/utils/sykmeldingUtils.js
@@ -3,14 +3,14 @@ import { erSykmeldingGyldigForOppfolgingMedGrensedato } from './oppfolgingsdialo
 export const sykmeldtHarNaermestelederHosArbeidsgiver = (virksomhetsnummer, naermesteLedere) => {
   return (
     naermesteLedere.filter((leder) => {
-      return virksomhetsnummer === leder.virksomhetsnummer;
+      return virksomhetsnummer === leder.virksomhetsnummer && leder.erAktiv;
     }).length > 0
   );
 };
 
 export const finnSykmeldtSinNaermestelederNavnHosArbeidsgiver = (virksomhetsnummer, naermesteLedere) => {
   const naermesteLeder = naermesteLedere.filter((leder) => {
-    return virksomhetsnummer === leder.virksomhetsnummer;
+    return virksomhetsnummer === leder.virksomhetsnummer && leder.erAktiv;
   })[0];
   return naermesteLeder ? naermesteLeder.navn : undefined;
 };

--- a/test/mock/mockLedere.js
+++ b/test/mock/mockLedere.js
@@ -5,6 +5,7 @@ export const getLedere = [
     mobil: '99988777',
     virksomhetsnummer: '123456789',
     organisasjonsnavn: 'Arbeidsgiver AS',
+    erAktiv: true,
     aktivTom: null,
   },
   {
@@ -13,6 +14,7 @@ export const getLedere = [
     mobil: '99988777',
     virksomhetsnummer: '123456788',
     organisasjonsnavn: 'Arbeidsgiver',
+    erAktiv: true,
     aktivTom: null,
   },
 ];


### PR DESCRIPTION
En bug i oppfølgingsplan gjorde at sykmeldte med deaktivert nærmeste leder fikk opp knappen "Lag ny oppfølgingsplan". Når de trykket på denne så feilet det i syfooppfolgingsplanservice fordi de ikke har en nærmeste leder. 

En nærmeste leder-relasjon blir deaktivert når den sykmeldte sender inn sykmelding og oppgir at ingen av de oppgitte lederne er deres nærmeste leder.